### PR TITLE
change `providers` filed seperator to semicolon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ This is the keyword to activate this ulauncher. If you type a argument after the
 
 *providers*   
 default:   
-This field contains one entry per line. Each line will contain a name and a secret seperated by a equals sign.
+This field contains multi entry seperated by semicolon. Each entry will contain a name and a secret seperated by a equals sign.
 Example:
 ```
-gitlab=abcd efgh 1234 fake fake 4321
-gitlab=1236 1248 test fail
+gitlab=abcd efgh 1234 fake fake 4321; gitlab=1236 1248 test fail
 ```
 This has been tested with gitlab and github.
 

--- a/main.py
+++ b/main.py
@@ -22,14 +22,14 @@ class KeywordQueryEventListener(EventListener):
 
         data = event.get_argument()
 
-        providers = extension.preferences.get('tfa_providers').splitlines()
+        providers = extension.preferences.get('tfa_providers').split(";")
 
         for provider in providers:
             if data:
                 if data not in provider:
                     continue
 
-            secrets = provider.split("=")
+            secrets = provider.strip().split("=")
             name = secrets[0]
             token = str(otp.get_totp(secrets[1])).zfill(6)
 

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
       "id": "tfa_providers",
       "type": "text",
       "name": "providers",
-      "description": "Every line is a key value pair: <br/>google=123123fAkE<br/>google2=321321FaKe<br/><br/><b>Make a backup of the above values!"
+      "description": "Seperate each key value pair by semicolon. Example: google=123123fAkE; google2=321321FaKe"
     }
   ]
 }


### PR DESCRIPTION
Because I cannot enter multi-line in `providers` field, so push this pr to change seperator to `;`。